### PR TITLE
increased rate limit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stattleshipR
 Title: R Interface to Query the Stattleship API
-Version: 0.0.2
+Version: 0.0.3
 Author: Brock Tibert, Tanya Cashorali
 Maintainer: Tanya Cashorali <tanyacash@gmail.com>
 Description: Provides an easy to use R wrapper around the Stattleship API that

--- a/R/ss_get_result.R
+++ b/R/ss_get_result.R
@@ -87,7 +87,7 @@ ss_get_result <- function(token,
         
         ## sleep the response: 
         ## limited to 300calls/5 minutes, so stay safe at 1.1
-        Sys.sleep(1.1)
+        Sys.sleep(.8)
       }
       
     }#endif(pages)


### PR DESCRIPTION
Changed the sleep to allow faster walks, and updated the simple version
for easier reference on package versions.  This addresses the issue https://github.com/stattleship/stattleship-r/issues/21.

The current limits:

`:limit => 5000, :period => 1.hour` setting (current threshold per IP).
