### PR TITLE
add baseball and mlb data to the API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stattleshipR
 Title: R Interface to Query the Stattleship API
-Version: 0.0.3
+Version: 0.0.4
 Author: Brock Tibert, Tanya Cashorali
 Maintainer: Tanya Cashorali <tanyacash@gmail.com>
 Description: Provides an easy to use R wrapper around the Stattleship API that

--- a/R/ss_get_result.R
+++ b/R/ss_get_result.R
@@ -2,8 +2,8 @@
 #' 
 #' A simple, generic function to query data from the Stattleship API
 #' 
-#' @param sport character. The sport, such as hockey, basketball, football. Default is hockey.
-#' @param league character. NHL, NBA, NFL, etc. Default is nhl.
+#' @param sport character. The sport, such as hockey, basketball, football, and baseball. Default is hockey.
+#' @param league character. NHL, NBA, NFL, and MLB. Default is nhl.
 #' @param ep character. The endpoint.  Default is teams.
 #' @param query list. A list that defines the query parameters. Default is empty list.
 #' @param version numeric. The API version. Current version is 1 and is the default value.
@@ -148,8 +148,8 @@ ss_get_result <- function(token,
   ep = tolower(ep)
   
   ## enforce some basics
-  stopifnot(sport %in% c("hockey", "basketball", "football"),
-            league %in% c("nhl", "nba", "nfl"))
+  stopifnot(sport %in% c("hockey", "basketball", "football", "baseball"),
+            league %in% c("nhl", "nba", "nfl", "mlb"))
   
   ## build the URL and the endpoint
   URL <- sprintf("https://www.stattleship.com/%s/%s/%s", sport, league, ep)

--- a/man/ss_get_result.Rd
+++ b/man/ss_get_result.Rd
@@ -9,9 +9,9 @@ ss_get_result(token, sport = "hockey", league = "nhl", ep = "teams",
   verbose = TRUE)
 }
 \arguments{
-\item{sport}{character. The sport, such as hockey, basketball, football. Default is hockey.}
+\item{sport}{character. The sport, such as hockey, basketball, football, and baseball. Default is hockey.}
 
-\item{league}{character. NHL, NBA, NFL, etc. Default is nhl.}
+\item{league}{character. NHL, NBA, NFL, and MLB. Default is nhl.}
 
 \item{ep}{character. The endpoint.  Default is teams.}
 


### PR DESCRIPTION
# A quick test for adding MLB
## what are the teams

`teams <- ss_get_result(ep = "teams", sport = "baseball", league = "mlb", walk=TRUE)`
`length(teams)`
`teams[[1]]$teams`
